### PR TITLE
Align access token module with project conventions

### DIFF
--- a/access-token/README.md
+++ b/access-token/README.md
@@ -1,0 +1,109 @@
+---
+title: "Access Token Pattern in Java: Secure Microservice Communication with JWT-style Tokens"
+shortTitle: Access Token
+description: "Implement the Access Token pattern in Java to decouple authentication from microservices, enforce scopes, and handle token refresh." 
+category: Microservices
+language: en
+tag:
+  - Authentication
+  - Authorization
+  - Microservices
+  - Security
+  - Cloud distributed
+---
+
+## Intent of the Access Token Design Pattern
+
+The Access Token pattern externalizes authentication and authorization concerns to a dedicated authorization service. Microservices rely on the issued tokens to validate identity and permissions without embedding authentication logic in every service.
+
+## Also known as
+
+* Token-based security
+* OAuth2 bearer tokens
+
+## Detailed Explanation of the Access Token Pattern with Real-World Examples
+
+Real-world example
+
+> In a retail platform, a centralized authorization server issues OAuth2 access tokens to shopping cart, catalog, and payment services. Each microservice validates the token before serving a request, ensuring that the caller is authenticated and has the right scope, while the authorization server manages refresh tokens and token expiry.
+
+In plain words
+
+> Instead of letting every microservice maintain its own authentication logic, a separate server issues signed tokens. Microservices inspect the token to decide whether a call is allowed.
+
+Wikipedia says
+
+> In OAuth 2.0, a bearer token is issued by an authorization server and used by the client to access protected resources. Resource servers validate the token and grant or deny access accordingly.
+
+## Programmatic Example of the Access Token Pattern in Java
+
+The example demonstrates how an authorization server issues signed tokens that microservices can validate. Tokens include scopes that describe the operations the caller can perform and an expiration time that limits how long the token is valid. Refresh tokens allow clients to request a new access token without re-authenticating.
+
+```java
+var clock = Clock.systemUTC();
+var tokenService = new TokenService("super-secret-signing-key", clock);
+var authorizationServer = new AuthorizationServer(tokenService, Duration.ofMinutes(5), Duration.ofHours(1), clock);
+var tokenValidator = new TokenValidator(tokenService, clock);
+var orderService = new ProtectedService("OrderService", "orders:read", tokenValidator);
+
+var tokenPair = authorizationServer.issueToken("reporting-service", Set.of("orders:read"));
+orderService.handleRequest(tokenPair.accessToken()); // succeeds
+
+// Billing service requires a different scope
+var billingService = new ProtectedService("BillingService", "billing:charge", tokenValidator);
+try {
+  billingService.handleRequest(tokenPair.accessToken());
+} catch (AccessDeniedException ex) {
+  System.out.println("Billing request rejected: " + ex.getMessage());
+}
+
+var refreshed = authorizationServer.refreshAccessToken(tokenPair.refreshToken())
+    .orElseThrow();
+orderService.handleRequest(refreshed); // still valid after refresh
+```
+
+## When to Use the Access Token Pattern in Java
+
+* When multiple microservices must trust the same authentication mechanism.
+* When you want to enforce scopes and permissions without centralizing all logic in one gateway.
+* When clients need long-running sessions that can be renewed via refresh tokens without storing credentials.
+
+## Real-World Applications of the Access Token Pattern in Java
+
+* Popular identity platforms such as Okta, Auth0, and Azure Active Directory rely on access tokens to
+  secure third-party integrations and first-party microservices.
+* Cloud providers like Google Cloud and AWS issue short-lived OAuth 2.0 tokens for service-to-service
+  communication, ensuring workloads authenticate without long-term credentials.
+* Enterprise API gateways frequently validate JWT access tokens to authorize partner applications and
+  mobile clients.
+
+## Benefits and Trade-offs of the Access Token Pattern
+
+Benefits:
+
+* Allows microservices to focus on business logic while relying on a shared authorization mechanism.
+* Enables fine-grained access control with token scopes and claims.
+* Supports stateless, scalable authentication since resource servers do not store session state.
+* Refresh tokens improve usability by letting clients renew tokens without re-authenticating.
+
+Trade-offs:
+
+* Requires secure management of signing keys and HTTPS communication to protect tokens.
+* Introduces complexity when implementing rotation and revocation of refresh tokens.
+* Tokens must be carefully scoped to avoid privilege escalation.
+
+## Related Java Design Patterns
+
+* [Gateway](https://java-design-patterns.com/patterns/gateway/): Both patterns encapsulate
+  external service access; Gateways can delegate authorization to token validation services.
+* [Microservices API Gateway](https://java-design-patterns.com/patterns/microservices-api-gateway/):
+  API gateways commonly validate access tokens before routing requests to downstream services.
+* [Service Layer](https://java-design-patterns.com/patterns/service-layer/): Service boundaries often
+  rely on access tokens to enforce cross-service security policies defined in the service layer.
+
+## References and Credits
+
+* [OAuth 2.0](https://oauth.net/2/)
+* [JSON Web Tokens (JWT.io)](https://jwt.io/introduction)
+* [Spring Security OAuth 2.0](https://docs.spring.io/spring-security/reference/servlet/oauth2/index.html)
+* [Microservices Security Patterns](https://microservices.io/patterns/security/microservice-security.html)

--- a/access-token/pom.xml
+++ b/access-token/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    This project is licensed under the MIT license. Module model-view-viewmodel is using ZK framework licensed under LGPL (see lgpl-3.0.txt).
+
+    The MIT License
+    Copyright © 2014-2022 Ilkka Seppälä
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.iluwatar</groupId>
+    <artifactId>java-design-patterns</artifactId>
+    <version>1.26.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>access-token</artifactId>
+  <packaging>jar</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <configuration>
+              <archive>
+                <manifest>
+                  <mainClass>com.iluwatar.accesstoken.App</mainClass>
+                </manifest>
+              </archive>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/access-token/src/main/java/com/iluwatar/accesstoken/AccessDeniedException.java
+++ b/access-token/src/main/java/com/iluwatar/accesstoken/AccessDeniedException.java
@@ -1,0 +1,36 @@
+/*
+ * This project is licensed under the MIT license. Module model-view-viewmodel is using ZK framework
+ * licensed under LGPL (see lgpl-3.0.txt).
+ *
+ * The MIT License
+ * Copyright © 2014-2022 Ilkka Seppälä
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.iluwatar.accesstoken;
+
+/**
+ * Exception thrown when a token is invalid, expired, or lacks the required scope for a request.
+ */
+public class AccessDeniedException extends RuntimeException {
+
+  public AccessDeniedException(String message) {
+    super(message);
+  }
+}

--- a/access-token/src/main/java/com/iluwatar/accesstoken/App.java
+++ b/access-token/src/main/java/com/iluwatar/accesstoken/App.java
@@ -1,0 +1,74 @@
+/*
+ * This project is licensed under the MIT license. Module model-view-viewmodel is using ZK framework
+ * licensed under LGPL (see lgpl-3.0.txt).
+ *
+ * The MIT License
+ * Copyright © 2014-2022 Ilkka Seppälä
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.iluwatar.accesstoken;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link App} class demonstrates how access tokens allow microservices to validate
+ * incoming requests without maintaining their own authentication logic. An authorization server
+ * issues tokens with scopes and expiry information, while individual services verify that
+ * the presented token is still valid and grants the required permissions.
+ */
+public class App {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(App.class);
+
+  /**
+   * Entry point of the example program.
+   */
+  public static void main(String[] args) {
+    var clock = Clock.systemUTC();
+    var tokenService = new TokenService("super-secret-signing-key", clock);
+    var authorizationServer = new AuthorizationServer(
+        tokenService, Duration.ofMinutes(5), Duration.ofHours(1), clock);
+    var tokenValidator = new TokenValidator(tokenService, clock);
+
+    var orderService = new ProtectedService("OrderService", "orders:read", tokenValidator);
+    var billingService = new ProtectedService("BillingService", "billing:charge", tokenValidator);
+
+    LOGGER.info("Requesting access token for reporting-service");
+    var tokenPair = authorizationServer.issueToken("reporting-service", Set.of("orders:read"));
+
+    LOGGER.info("Obtained access token for reporting-service");
+    LOGGER.info("Order service response: {}", orderService.handleRequest(tokenPair.accessToken()));
+
+    try {
+      billingService.handleRequest(tokenPair.accessToken());
+    } catch (AccessDeniedException ex) {
+      LOGGER.warn("Billing request rejected: {}", ex.getMessage());
+    }
+
+    LOGGER.info("Refreshing access token using stored refresh token");
+    authorizationServer.refreshAccessToken(tokenPair.refreshToken())
+        .ifPresent(refreshed -> LOGGER.info("Refreshed token accepted by OrderService: {}",
+            orderService.handleRequest(refreshed)));
+  }
+}

--- a/access-token/src/main/java/com/iluwatar/accesstoken/AuthorizationServer.java
+++ b/access-token/src/main/java/com/iluwatar/accesstoken/AuthorizationServer.java
@@ -1,0 +1,89 @@
+/*
+ * This project is licensed under the MIT license. Module model-view-viewmodel is using ZK framework
+ * licensed under LGPL (see lgpl-3.0.txt).
+ *
+ * The MIT License
+ * Copyright © 2014-2022 Ilkka Seppälä
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.iluwatar.accesstoken;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Issues access tokens and refresh tokens. The authorization server authenticates the caller (omitted
+ * in the example) and produces signed tokens for resource servers to validate.
+ */
+public class AuthorizationServer {
+
+  private final TokenService tokenService;
+  private final Duration accessTokenTtl;
+  private final Duration refreshTokenTtl;
+  private final Clock clock;
+  private final Map<String, RefreshTokenInfo> refreshTokens = new ConcurrentHashMap<>();
+
+  public AuthorizationServer(TokenService tokenService, Duration accessTokenTtl,
+      Duration refreshTokenTtl, Clock clock) {
+    this.tokenService = tokenService;
+    this.accessTokenTtl = accessTokenTtl;
+    this.refreshTokenTtl = refreshTokenTtl;
+    this.clock = clock;
+  }
+
+  /**
+   * Issues an access token and a refresh token for the authenticated principal.
+   */
+  public TokenPair issueToken(String subject, Set<String> scopes) {
+    var accessToken = tokenService.generateToken(subject, scopes, accessTokenTtl);
+    var refreshToken = UUID.randomUUID().toString();
+    refreshTokens.put(refreshToken,
+        new RefreshTokenInfo(subject, Set.copyOf(scopes), clock.instant().plus(refreshTokenTtl)));
+    return new TokenPair(accessToken, refreshToken);
+  }
+
+  /**
+   * Uses the refresh token to obtain a new access token.
+   */
+  public Optional<String> refreshAccessToken(String refreshToken) {
+    var info = refreshTokens.get(refreshToken);
+    if (info == null) {
+      return Optional.empty();
+    }
+
+    if (!info.isValidAt(clock.instant())) {
+      refreshTokens.remove(refreshToken);
+      return Optional.empty();
+    }
+
+    return Optional.of(tokenService.generateToken(info.subject(), info.scopes(), accessTokenTtl));
+  }
+
+  private record RefreshTokenInfo(String subject, Set<String> scopes, java.time.Instant expiresAt) {
+    private boolean isValidAt(java.time.Instant instant) {
+      return expiresAt.isAfter(instant);
+    }
+  }
+}

--- a/access-token/src/main/java/com/iluwatar/accesstoken/ProtectedService.java
+++ b/access-token/src/main/java/com/iluwatar/accesstoken/ProtectedService.java
@@ -1,0 +1,57 @@
+/*
+ * This project is licensed under the MIT license. Module model-view-viewmodel is using ZK framework
+ * licensed under LGPL (see lgpl-3.0.txt).
+ *
+ * The MIT License
+ * Copyright © 2014-2022 Ilkka Seppälä
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.iluwatar.accesstoken;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Represents a microservice that trusts the authorization server. The service relies on the
+ * {@link TokenValidator} to make authorization decisions instead of storing authentication state.
+ */
+public class ProtectedService {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ProtectedService.class);
+
+  private final String serviceName;
+  private final String requiredScope;
+  private final TokenValidator tokenValidator;
+
+  public ProtectedService(String serviceName, String requiredScope, TokenValidator tokenValidator) {
+    this.serviceName = serviceName;
+    this.requiredScope = requiredScope;
+    this.tokenValidator = tokenValidator;
+  }
+
+  /**
+   * Processes a request secured by an access token.
+   */
+  public String handleRequest(String token) {
+    var claims = tokenValidator.requireScope(token, requiredScope);
+    LOGGER.info("{} accepted request from subject {}", serviceName, claims.subject());
+    return serviceName + " data for " + claims.subject();
+  }
+}

--- a/access-token/src/main/java/com/iluwatar/accesstoken/TokenClaims.java
+++ b/access-token/src/main/java/com/iluwatar/accesstoken/TokenClaims.java
@@ -1,0 +1,58 @@
+/*
+ * This project is licensed under the MIT license. Module model-view-viewmodel is using ZK framework
+ * licensed under LGPL (see lgpl-3.0.txt).
+ *
+ * The MIT License
+ * Copyright © 2014-2022 Ilkka Seppälä
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.iluwatar.accesstoken;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Immutable representation of the claims embedded in an access token.
+ */
+public record TokenClaims(String subject, Set<String> scopes, Instant issuedAt, Instant expiresAt) {
+
+  public TokenClaims {
+    Objects.requireNonNull(subject, "subject");
+    Objects.requireNonNull(scopes, "scopes");
+    Objects.requireNonNull(issuedAt, "issuedAt");
+    Objects.requireNonNull(expiresAt, "expiresAt");
+    this.scopes = Set.copyOf(scopes);
+  }
+
+  /**
+   * Returns {@code true} when the token contains the provided scope.
+   */
+  public boolean hasScope(String scope) {
+    return scopes.contains(scope);
+  }
+
+  /**
+   * Indicates whether the token should be considered expired at the provided instant.
+   */
+  public boolean isExpired(Instant instant) {
+    return !expiresAt.isAfter(instant);
+  }
+}

--- a/access-token/src/main/java/com/iluwatar/accesstoken/TokenPair.java
+++ b/access-token/src/main/java/com/iluwatar/accesstoken/TokenPair.java
@@ -1,0 +1,39 @@
+/*
+ * This project is licensed under the MIT license. Module model-view-viewmodel is using ZK framework
+ * licensed under LGPL (see lgpl-3.0.txt).
+ *
+ * The MIT License
+ * Copyright © 2014-2022 Ilkka Seppälä
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.iluwatar.accesstoken;
+
+import java.util.Objects;
+
+/**
+ * Represents the pair of access and refresh tokens returned by the authorization server.
+ */
+public record TokenPair(String accessToken, String refreshToken) {
+
+  public TokenPair {
+    Objects.requireNonNull(accessToken, "accessToken");
+    Objects.requireNonNull(refreshToken, "refreshToken");
+  }
+}

--- a/access-token/src/main/java/com/iluwatar/accesstoken/TokenService.java
+++ b/access-token/src/main/java/com/iluwatar/accesstoken/TokenService.java
@@ -1,0 +1,156 @@
+/*
+ * This project is licensed under the MIT license. Module model-view-viewmodel is using ZK framework
+ * licensed under LGPL (see lgpl-3.0.txt).
+ *
+ * The MIT License
+ * Copyright © 2014-2022 Ilkka Seppälä
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.iluwatar.accesstoken;
+
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.MessageDigest;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.LinkedHashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Service that issues and validates signed tokens. The implementation uses a simple HMAC signature and
+ * encodes the token payload using base64-url. The payload structure is intentionally easy to inspect so
+ * that microservices can extract the claims without contacting the authorization server.
+ */
+public class TokenService {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(TokenService.class);
+  private static final String HMAC_ALGORITHM = "HmacSHA256";
+  private static final String FIELD_SEPARATOR = "|";
+
+  private final Clock clock;
+  private final SecretKeySpec secretKey;
+
+  public TokenService(String secret, Clock clock) {
+    this.clock = clock;
+    this.secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), HMAC_ALGORITHM);
+  }
+
+  /**
+   * Generates a signed access token containing the provided claims.
+   */
+  public String generateToken(String subject, Set<String> scopes, Duration timeToLive) {
+    var issuedAt = clock.instant();
+    var expiresAt = issuedAt.plus(timeToLive);
+    var serializedScopes = scopes.stream().sorted().collect(Collectors.joining(","));
+    var payload = subject + FIELD_SEPARATOR + issuedAt.toEpochMilli() + FIELD_SEPARATOR
+        + expiresAt.toEpochMilli() + FIELD_SEPARATOR + serializedScopes;
+    var encodedPayload = Base64.getUrlEncoder().withoutPadding()
+        .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
+    var signature = Base64.getUrlEncoder().withoutPadding().encodeToString(sign(encodedPayload));
+    return encodedPayload + '.' + signature;
+  }
+
+  /**
+   * Parses a token and verifies its signature. Returns an {@link Optional#empty()} when the token is
+   * malformed or the signature check fails.
+   */
+  public Optional<TokenClaims> parse(String token) {
+    if (token == null || token.isBlank()) {
+      return Optional.empty();
+    }
+
+    var segments = token.split("\\.");
+    if (segments.length != 2) {
+      LOGGER.warn("Token does not contain two segments");
+      return Optional.empty();
+    }
+
+    var payload = segments[0];
+    var providedSignature = decodeUrlSafe(segments[1]);
+    var expectedSignature = sign(payload);
+
+    if (providedSignature.isEmpty()) {
+      return Optional.empty();
+    }
+
+    if (!MessageDigest.isEqual(providedSignature.get(), expectedSignature)) {
+      LOGGER.warn("Token signature mismatch");
+      return Optional.empty();
+    }
+
+    return decodeClaims(payload);
+  }
+
+  private Optional<TokenClaims> decodeClaims(String encodedPayload) {
+    try {
+      var decodedPayload = new String(Base64.getUrlDecoder().decode(encodedPayload),
+          StandardCharsets.UTF_8);
+      var fields = decodedPayload.split("\\|", -1);
+      if (fields.length != 4) {
+        LOGGER.warn("Token payload did not contain expected number of fields");
+        return Optional.empty();
+      }
+
+      var subject = fields[0];
+      var issuedAt = Instant.ofEpochMilli(Long.parseLong(fields[1]));
+      var expiresAt = Instant.ofEpochMilli(Long.parseLong(fields[2]));
+      var scopeField = fields[3];
+      Set<String> scopes;
+      if (scopeField.isEmpty()) {
+        scopes = Set.of();
+      } else {
+        scopes = Arrays.stream(scopeField.split(","))
+            .collect(Collectors.toCollection(LinkedHashSet::new));
+      }
+      return Optional.of(new TokenClaims(subject, scopes, issuedAt, expiresAt));
+    } catch (IllegalArgumentException e) {
+      LOGGER.warn("Failed to decode token payload", e);
+      return Optional.empty();
+    }
+  }
+
+  private byte[] sign(String data) {
+    try {
+      var mac = Mac.getInstance(HMAC_ALGORITHM);
+      mac.init(secretKey);
+      return mac.doFinal(data.getBytes(StandardCharsets.UTF_8));
+    } catch (GeneralSecurityException e) {
+      throw new IllegalStateException("Could not sign token", e);
+    }
+  }
+
+  private Optional<byte[]> decodeUrlSafe(String data) {
+    try {
+      return Optional.of(Base64.getUrlDecoder().decode(data));
+    } catch (IllegalArgumentException ex) {
+      LOGGER.warn("Failed to decode signature", ex);
+      return Optional.empty();
+    }
+  }
+}

--- a/access-token/src/main/java/com/iluwatar/accesstoken/TokenValidator.java
+++ b/access-token/src/main/java/com/iluwatar/accesstoken/TokenValidator.java
@@ -1,0 +1,64 @@
+/*
+ * This project is licensed under the MIT license. Module model-view-viewmodel is using ZK framework
+ * licensed under LGPL (see lgpl-3.0.txt).
+ *
+ * The MIT License
+ * Copyright © 2014-2022 Ilkka Seppälä
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.iluwatar.accesstoken;
+
+import java.time.Clock;
+import java.util.Optional;
+
+/**
+ * Validates incoming tokens on behalf of microservices. The validator checks that the token is well
+ * formed, signed by the trusted authority, has not expired yet, and provides the required scope.
+ */
+public class TokenValidator {
+
+  private final TokenService tokenService;
+  private final Clock clock;
+
+  public TokenValidator(TokenService tokenService, Clock clock) {
+    this.tokenService = tokenService;
+    this.clock = clock;
+  }
+
+  /**
+   * Parses and validates a token. Returns an empty optional when the token is invalid or expired.
+   */
+  public Optional<TokenClaims> validate(String token) {
+    return tokenService.parse(token)
+        .filter(claims -> !claims.isExpired(clock.instant()));
+  }
+
+  /**
+   * Ensures that the provided token is valid and contains the requested scope.
+   */
+  public TokenClaims requireScope(String token, String scope) {
+    var claims = validate(token)
+        .orElseThrow(() -> new AccessDeniedException("Token is invalid or expired"));
+    if (!claims.hasScope(scope)) {
+      throw new AccessDeniedException("Token is missing scope: " + scope);
+    }
+    return claims;
+  }
+}

--- a/access-token/src/test/java/com/iluwatar/accesstoken/AppTest.java
+++ b/access-token/src/test/java/com/iluwatar/accesstoken/AppTest.java
@@ -1,0 +1,39 @@
+/*
+ * This project is licensed under the MIT license. Module model-view-viewmodel is using ZK framework
+ * licensed under LGPL (see lgpl-3.0.txt).
+ *
+ * The MIT License
+ * Copyright © 2014-2022 Ilkka Seppälä
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.iluwatar.accesstoken;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.junit.jupiter.api.Test;
+
+/** Application test. */
+class AppTest {
+
+  @Test
+  void shouldRunMainWithoutExceptions() {
+    assertDoesNotThrow(() -> App.main(new String[]{}));
+  }
+}

--- a/access-token/src/test/java/com/iluwatar/accesstoken/AuthorizationServerTest.java
+++ b/access-token/src/test/java/com/iluwatar/accesstoken/AuthorizationServerTest.java
@@ -1,0 +1,101 @@
+/*
+ * This project is licensed under the MIT license. Module model-view-viewmodel is using ZK framework
+ * licensed under LGPL (see lgpl-3.0.txt).
+ *
+ * The MIT License
+ * Copyright © 2014-2022 Ilkka Seppälä
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.iluwatar.accesstoken;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class AuthorizationServerTest {
+
+  private final AdjustableClock clock = new AdjustableClock(
+      Instant.parse("2024-01-01T00:00:00Z"), ZoneOffset.UTC);
+  private final TokenService tokenService = new TokenService("secret", clock);
+  private final AuthorizationServer authorizationServer =
+      new AuthorizationServer(tokenService, Duration.ofMinutes(5), Duration.ofHours(1), clock);
+  private final TokenValidator validator = new TokenValidator(tokenService, clock);
+
+  @Test
+  void shouldIssueAndRefreshTokens() {
+    var pair = authorizationServer.issueToken("client", Set.of("orders:read", "inventory:write"));
+    var claims = validator.validate(pair.accessToken()).orElseThrow();
+
+    assertEquals("client", claims.subject());
+    assertEquals(Set.of("inventory:write", "orders:read"), claims.scopes());
+
+    clock.advance(Duration.ofMinutes(1));
+    var refreshed = authorizationServer.refreshAccessToken(pair.refreshToken()).orElseThrow();
+    var refreshedClaims = validator.validate(refreshed).orElseThrow();
+
+    assertEquals("client", refreshedClaims.subject());
+    assertTrue(refreshedClaims.expiresAt().isAfter(clock.instant()));
+  }
+
+  @Test
+  void shouldInvalidateExpiredRefreshToken() {
+    var pair = authorizationServer.issueToken("client", Set.of("orders:read"));
+
+    clock.advance(Duration.ofHours(2));
+
+    assertTrue(authorizationServer.refreshAccessToken(pair.refreshToken()).isEmpty());
+  }
+
+  private static class AdjustableClock extends Clock {
+
+    private Instant instant;
+    private final ZoneOffset zone;
+
+    private AdjustableClock(Instant instant, ZoneOffset zone) {
+      this.instant = instant;
+      this.zone = zone;
+    }
+
+    @Override
+    public ZoneOffset getZone() {
+      return zone;
+    }
+
+    @Override
+    public Clock withZone(java.time.ZoneId zone) {
+      return new AdjustableClock(instant, zone instanceof ZoneOffset offset ? offset : ZoneOffset.UTC);
+    }
+
+    @Override
+    public Instant instant() {
+      return instant;
+    }
+
+    private void advance(Duration duration) {
+      instant = instant.plus(duration);
+    }
+  }
+}

--- a/access-token/src/test/java/com/iluwatar/accesstoken/TokenValidatorTest.java
+++ b/access-token/src/test/java/com/iluwatar/accesstoken/TokenValidatorTest.java
@@ -1,0 +1,72 @@
+/*
+ * This project is licensed under the MIT license. Module model-view-viewmodel is using ZK framework
+ * licensed under LGPL (see lgpl-3.0.txt).
+ *
+ * The MIT License
+ * Copyright © 2014-2022 Ilkka Seppälä
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.iluwatar.accesstoken;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class TokenValidatorTest {
+
+  private static final Instant ISSUED_AT = Instant.parse("2024-01-01T00:00:00Z");
+  private final Clock clock = Clock.fixed(ISSUED_AT, ZoneOffset.UTC);
+  private final TokenService tokenService = new TokenService("secret", clock);
+
+  @Test
+  void shouldReturnClaimsForValidToken() {
+    var validator = new TokenValidator(tokenService, clock);
+    var token = tokenService.generateToken("client", Set.of("orders:read"), Duration.ofMinutes(5));
+
+    var claims = validator.validate(token).orElseThrow();
+
+    assertEquals("client", claims.subject());
+    assertTrue(claims.hasScope("orders:read"));
+  }
+
+  @Test
+  void shouldThrowWhenScopeMissing() {
+    var validator = new TokenValidator(tokenService, clock);
+    var token = tokenService.generateToken("client", Set.of("orders:read"), Duration.ofMinutes(5));
+
+    assertThrows(AccessDeniedException.class, () -> validator.requireScope(token, "billing:charge"));
+  }
+
+  @Test
+  void shouldReturnEmptyWhenExpired() {
+    var token = tokenService.generateToken("client", Set.of("orders:read"), Duration.ZERO);
+    var later = Clock.fixed(ISSUED_AT.plusSeconds(1), ZoneOffset.UTC);
+    var validator = new TokenValidator(tokenService, later);
+
+    assertTrue(validator.validate(token).isEmpty());
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
   </properties>
   <modules>
 
+    <module>access-token</module>
     <module>abstract-document</module>
     <module>abstract-factory</module>
     <module>active-object</module>


### PR DESCRIPTION
## Summary
- add the MIT license header to the access-token module sources and tests and adjust AppTest to use `assertDoesNotThrow`
- expand the access-token README with real-world usage notes, related patterns, and references to match repository documentation style

## Testing
- mvn -pl access-token test *(fails: jitpack.io returns HTTP 403 for required artifacts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4adb6eca4832d9d1a574e4483ba55